### PR TITLE
fix: running status and gracefully exit

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -126,8 +126,7 @@ func restoreRunningState() (err error) {
 			return fmt.Errorf("%w; %v", err, err2)
 		}
 		if err2 := tx2.Model(&sys).Updates(map[string]interface{}{
-			"running":  false,
-			"modified": false,
+			"running": false,
 		}).Error; err2 != nil {
 			tx2.Rollback()
 			return fmt.Errorf("%w; %v", err, err2)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -57,13 +57,15 @@ var (
 
 			// Run dae.
 			go func() {
-				logrus.Fatalln(dae.Run(
+				if err := dae.Run(
 					logrus.StandardLogger(),
 					dae.EmptyConfig,
 					[]string{cfgDir},
 					disableTimestamp,
 					apiOnly,
-				))
+				); err != nil {
+					logrus.Fatalln("dae.Run:", err)
+				}
 			}()
 			// Reload with running state.
 			if err := restoreRunningState(); err != nil {
@@ -75,6 +77,7 @@ var (
 			if err != nil {
 				logrus.Errorf("Exiting: %v", err)
 				dae.ChReloadConfigs <- nil
+				<-dae.GracefullyExit
 				os.Exit(1)
 			}
 			http.Handle("/graphql", auth(cors.AllowAll().Handler(&relay.Handler{Schema: schema})))
@@ -84,6 +87,7 @@ var (
 					// Notify to Close().
 					logrus.Errorf("Exiting: %v", err)
 					dae.ChReloadConfigs <- nil
+					<-dae.GracefullyExit
 					os.Exit(1)
 				}
 			}()
@@ -93,6 +97,7 @@ var (
 				// Notify to Close().
 				logrus.Errorf("Exiting: %v", sig.String())
 				dae.ChReloadConfigs <- nil
+				<-dae.GracefullyExit
 				return
 			}
 		},

--- a/dae/dae.go
+++ b/dae/dae.go
@@ -99,10 +99,7 @@ loop:
 				<-readyChan
 				log.Warnln("[Reload] Finished")
 				/* dae-wing start */
-				if !isRollback {
-					// To notify the success.
-					chCallback <- true
-				}
+				chCallback <- !isRollback
 				/* dae-wing end */
 			} else {
 				// Listening error.
@@ -143,8 +140,13 @@ loop:
 				}
 				newConf = conf
 				log.Errorln("[Reload] Last reload failed; rolled back configuration")
+
+				/* dae-wing start */
+				isRollback = true
+				/* dae-wing end */
 			} else {
 				log.Warnln("[Reload] Stopped old control plane")
+
 				/* dae-wing start */
 				isRollback = false
 				/* dae-wing end */

--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -289,10 +289,9 @@ func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
 		}
 	}
 	var separateNodes []db.Node
-	if err = d.Model(&db.Group{}).
-		Where("name in ?", outbounds).
+	if err = d.Model(groups).
 		Association("Node").
-		Find(&separateNodes, "subscription_id not in ?", subIds); err != nil {
+		Find(&separateNodes, "subscription_id is null"); err != nil {
 		return 0, err
 	}
 	nodes = append(nodes, separateNodes...)


### PR DESCRIPTION
# Background

1. Cannot run in the non-dry run environment because no node found by dae-wing.
2. ebpf was not cleaned after exiting.

# Modification

1. Wait for control plane closed and gracefully exit.
2. Fix the node finding.