### PR TITLE
optimize: optimize memory occupation of bundled web resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,5 +56,12 @@ bundle: deps
 	@if [ $$(realpath -m "$(WEB_DIST)") != $$(realpath -m "webrender/web") ]; then \
 		rm -r webrender/web 2>/dev/null; \
 		cp -r $(WEB_DIST) webrender/web; \
+		find webrender/web -type f -size +16k ! -name "*.gz" ! -name "*.woff"  ! -name "*.woff2" -exec $$SHELL -c '\
+			gzip -9 -k '{}'; \
+			if [ "$$(stat -c %s {})" \< "$$(stat -c %s {}.gz)" ]; then \
+				rm {}.gz; \
+			else \
+				rm {}; \
+			fi' ';' ; \
 	fi && \
 	go build -tags=embedallowed -o $(OUTPUT) -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=$(VERSION)" .

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ bundle: deps
 	@if [ $$(realpath -m "$(WEB_DIST)") != $$(realpath -m "webrender/web") ]; then \
 		rm -r webrender/web 2>/dev/null; \
 		cp -r $(WEB_DIST) webrender/web; \
-		find webrender/web -type f -size +16k ! -name "*.gz" ! -name "*.woff"  ! -name "*.woff2" -exec $$SHELL -c '\
+		find webrender/web -type f -size +16k ! -name "*.gz" ! -name "*.woff"  ! -name "*.woff2" -exec sh -c '\
 			gzip -9 -k '{}'; \
 			if [ "$$(stat -c %s {})" \< "$$(stat -c %s {}.gz)" ]; then \
 				rm {}.gz; \

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/daeuniverse/dae-wing
 go 1.18
 
 require (
-	github.com/NYTimes/gziphandler v1.1.1
 	github.com/daeuniverse/dae v0.0.0-20230609141255-e1d0d8a35a60
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/graph-gophers/graphql-go v1.5.1-0.20230228210639-f05ace9f4a41

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
-github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=

--- a/webrender/webrender.go
+++ b/webrender/webrender.go
@@ -13,7 +13,6 @@ import (
 	"io/fs"
 	"net/http"
 
-	"github.com/NYTimes/gziphandler"
 	"github.com/vearutop/statigz"
 )
 
@@ -25,6 +24,6 @@ func Handle(mux *http.ServeMux) error {
 	if err != nil {
 		return fmt.Errorf("fs.Sub: %w", err)
 	}
-	mux.Handle("/", gziphandler.GzipHandler(statigz.FileServer(webFS.(fs.ReadDirFS))))
+	mux.Handle("/", statigz.FileServer(webFS.(fs.ReadDirFS)))
 	return nil
 }


### PR DESCRIPTION
# Motivation

`embed` static web files could be compressed to degrade memory occupation, because `go` will release them into memoery at once. 

# Modification

1. Remove runtime gzip.
2. gzip when bundling.
