### PR TITLE
chore(Makefile): allow giving GOMODCACHE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dae-wing
 
 # vendor
 vendor/
+go-mod/
 
 # build
 build-dae-ebpf/

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
 
+# Do NOT remove the line below. This line is for CI.
+#export GOMODCACHE=$(PWD)/go-mod
+
 all: dae-wing
 .PHONY: all
 


### PR DESCRIPTION
This PR allow CI (for full src packaging) giving `$GOMODCACHE` in Makefile.

For example:
https://github.com/daeuniverse/daed/pull/42