### PR TITLE
fix(render): nodes of subscription in group should be included

### DIFF
--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -352,7 +352,7 @@ func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
 		var solitaryNodes []db.Node
 		if err = d.Model(g).
 			Association("Node").
-			Find(&solitaryNodes, "subscription_id is null"); err != nil {
+			Find(&solitaryNodes); err != nil {
 			return 0, err
 		}
 		for _, n := range solitaryNodes {


### PR DESCRIPTION
# Background

Fix up a bug that nodes in subscriptions would not be included in a group in configuration rendering.

# Related

<https://github.com/daeuniverse/daed/pull/58#issuecomment-1595955936>