### PR TITLE
fix: modified was always true

### DIFF
--- a/db/system.go
+++ b/db/system.go
@@ -19,6 +19,6 @@ type System struct {
 	RunningDnsID     *uint
 	RunningDns       *Dns
 	RunningRoutingID *uint
-	RunningRouting   *Config
+	RunningRouting   *Routing
 	RunningGroups    []Group
 }


### PR DESCRIPTION
# Background

`general.dae.modified` always returned true if running is true.

# Change

Fix incorrect `type` of foreign key `RunningRouting`.