### PR TITLE
fix: add run lock to avoid locking database

### DIFF
--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/dae"
@@ -245,7 +246,13 @@ func Rename(ctx context.Context, _id graphql.ID, name string) (n int32, err erro
 	return int32(q.RowsAffected), nil
 }
 
+var runLock sync.Mutex
+
 func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
+	if ok := runLock.TryLock(); !ok {
+		return 0, fmt.Errorf("the last request didn't complete; make a cup of tea and take a break")
+	}
+	defer runLock.Unlock()
 	//// Dry run.
 	if noLoad {
 		ch := make(chan error)


### PR DESCRIPTION
# Background

```
2023/06/18 17:04:11 github.com/daeuniverse/dae-wing/graphql/service/config/mutation_utils.go:435 database is locked (5) 
```
Sometimes, in a special case, the database will lock.

# Change

See the image:

<img width="511" alt="image" src="https://github.com/daeuniverse/dae-wing/assets/30586220/6969196d-8dc4-485e-ad54-561af0342845">
