### PR TITLE
fix: tproxyPortProtect couldn't be updated

### DIFF
--- a/graphql/service/config/global/generator/input/input.go
+++ b/graphql/service/config/global/generator/input/input.go
@@ -7,13 +7,14 @@ package main
 
 import (
 	"fmt"
-	daeConfig "github.com/daeuniverse/dae/config"
-	"github.com/sirupsen/logrus"
-	"github.com/stoewer/go-strcase"
 	"os"
 	"reflect"
 	"strings"
 	"time"
+
+	daeConfig "github.com/daeuniverse/dae/config"
+	"github.com/sirupsen/logrus"
+	"github.com/stoewer/go-strcase"
 )
 
 type builder struct {
@@ -104,7 +105,9 @@ func (b *builder) Build() (string, error) {
 func (i *Input) Marshal() (string, error) {
 			var g daeConfig.Global
 			i.Assign(&g)
-			marshaller := daeConfig.Marshaller{}
+			marshaller := daeConfig.Marshaller{
+				IgnoreZero: true,
+			}
 			if err := marshaller.MarshalSection("global", reflect.ValueOf(g), 0); err != nil {
 				return "", err
 			}

--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -80,7 +80,12 @@ func Update(ctx context.Context, _id graphql.ID, inputGlobal global.Input) (*Res
 	// Assign input items to daeConfig.Global.
 	inputGlobal.Assign(&c.Global)
 	// Marshal back to string.
-	marshaller := daeConfig.Marshaller{IndentSpace: 2}
+	marshaller := daeConfig.Marshaller{
+		IndentSpace: 2,
+		// We do not ignore any zero value because all values are valid.
+		// That is to say, `ParseConfig` filled in all the values.
+		IgnoreZero: false,
+	}
 	if err = marshaller.MarshalSection("global", reflect.ValueOf(c.Global), 0); err != nil {
 		return nil, err
 	}

--- a/graphql/service/dns/mutation_utils.go
+++ b/graphql/service/dns/mutation_utils.go
@@ -8,12 +8,10 @@ package dns
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/dae"
 	"github.com/daeuniverse/dae-wing/db"
-	daeConfig "github.com/daeuniverse/dae/config"
 	"github.com/graph-gophers/graphql-go"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -60,14 +58,10 @@ func Update(ctx context.Context, _id graphql.ID, dns string) (*Resolver, error) 
 	}
 	// Prepare to partially update.
 	m.Dns = "dns {\n" + dns + "\n}"
-	// Marshal back to string to check the grammar.
+	// Parse it check the grammar.
 	c, err := dae.ParseConfig(nil, &m.Dns, nil)
 	if err != nil {
 		return nil, fmt.Errorf("bad current dns: %w", err)
-	}
-	marshaller := daeConfig.Marshaller{IndentSpace: 2}
-	if err = marshaller.MarshalSection("dns", reflect.ValueOf(c.Dns), 0); err != nil {
-		return nil, err
 	}
 	// Update.
 	if err = tx.Model(&db.Dns{ID: id}).Updates(map[string]interface{}{

--- a/graphql/service/routing/mutation_utils.go
+++ b/graphql/service/routing/mutation_utils.go
@@ -8,12 +8,10 @@ package routing
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/dae"
 	"github.com/daeuniverse/dae-wing/db"
-	daeConfig "github.com/daeuniverse/dae/config"
 	"github.com/graph-gophers/graphql-go"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -60,14 +58,10 @@ func Update(ctx context.Context, _id graphql.ID, routing string) (*Resolver, err
 	}
 	// Prepare to partially update.
 	m.Routing = "routing {\n" + routing + "\n}"
-	// Marshal back to string to check the grammar.
+	// Parse it to check the grammar.
 	c, err := dae.ParseConfig(nil, nil, &m.Routing)
 	if err != nil {
 		return nil, fmt.Errorf("bad current routing: %w", err)
-	}
-	marshaller := daeConfig.Marshaller{IndentSpace: 2}
-	if err = marshaller.MarshalSection("routing", reflect.ValueOf(c.Routing), 0); err != nil {
-		return nil, err
 	}
 	// Update.
 	if err = tx.Model(&db.Routing{ID: id}).Updates(map[string]interface{}{


### PR DESCRIPTION
## Background

`tproxyPortProtect` can't be updated.

## Changes

1. Upgrade `dae`.
2. Set `IgnoreZero` for marshaller according to the use scenario.
