### PR TITLE
fix: threw error if failed to subscribe any nodes

### DIFF
--- a/graphql/service/subscription/mutation_utils.go
+++ b/graphql/service/subscription/mutation_utils.go
@@ -105,7 +105,14 @@ func Import(c *gorm.DB, rollbackError bool, argument *internal.ImportArgument) (
 	if err != nil {
 		return nil, err
 	}
-	if len(result) == 0 {
+	hasAnyCandidate := false
+	for _, r := range result {
+		if r.Error == nil {
+			hasAnyCandidate = true
+			break
+		}
+	}
+	if !hasAnyCandidate {
 		return nil, fmt.Errorf("no any valid node can be imported")
 	}
 	return &ImportResult{
@@ -182,8 +189,15 @@ func Update(ctx context.Context, _id graphql.ID) (r *Resolver, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(result) == 0 {
-		return nil, fmt.Errorf("interrupt to update subscription: no any valid node can be imported: %v", m.Link)
+	hasAnyCandidate := false
+	for _, r := range result {
+		if r.Error == nil {
+			hasAnyCandidate = true
+			break
+		}
+	}
+	if !hasAnyCandidate {
+		return nil, fmt.Errorf("interrupt to update subscription: no any valid node can be imported")
 	}
 	// Update updated_at and return the latest version.
 	if err = tx.Model(&m).

--- a/graphql/service/subscription/mutation_utils.go
+++ b/graphql/service/subscription/mutation_utils.go
@@ -48,6 +48,9 @@ func fetchLinks(subscriptionLink string) (links []string, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to fetch link: %v", resp.Status)
+	}
 	defer resp.Body.Close()
 	b, err = io.ReadAll(resp.Body)
 	if err != nil {
@@ -60,6 +63,9 @@ func fetchLinks(subscriptionLink string) (links []string, err error) {
 	links, err = subscription.ResolveSubscriptionAsSIP008(noLogger, b)
 	if err != nil {
 		links = subscription.ResolveSubscriptionAsBase64(noLogger, b)
+	}
+	if len(links) == 0 {
+		return nil, fmt.Errorf("fetched but no any node was found")
 	}
 	return links, nil
 }
@@ -152,7 +158,7 @@ func Update(ctx context.Context, _id graphql.ID) (r *Resolver, err error) {
 			tx.Rollback()
 		}
 	}()
-	// Remove those subscription_id of which satisfied and are not independently in any groups.
+	// Remove those subscription_id of which satisfied and are independent from any groups.
 	subQuery := tx.Raw(`select nodes.id as id
                 from nodes
                 inner join group_nodes on group_nodes.node_id = nodes.id


### PR DESCRIPTION
## Background

Nodes of subscriptions may be cleared if failed.

## Changes

1. If no node is found after fetching, threw an error (pre-judgement).
2. If no node is actually imported, threw and error and rollback.

## Issue

Fix #43.

## Test

<https://github.com/daeuniverse/dae-wing/pull/48#issuecomment-1599064137>