### PR TITLE
chore(Makefile): fix full-src compilation incorrectly requires git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,10 @@ schema-resolver: $(DAE_READY)
 	go generate ./...
 .PHONY: schema-resolver
 
+$(DAE_EBPF_SRC):
+	@git submodule update --init --recursive dae-core
+
 $(DAE_READY): .gitmodules $(DAE_EBPF_SRC)
-	@git submodule update --init --recursive dae-core && \
 	cd dae-core && \
 	make ebpf && \
 	cd ../ && \


### PR DESCRIPTION
## Background

Full-src compilation incorrectly requires git.

## Change

Separate `submodule update` from `DAE_READY`.
