### PR TITLE
fix(running): colon in node name; dup node in filter; no node in group

### DIFF
--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/dae"
@@ -147,6 +148,19 @@ func deduplicateNodes(nodes []*node) []*node {
 	return ret
 }
 
+// normNodeName normalize the name to satify the "key" format in dae config.
+func normNodeName(_name string) string {
+	name := []rune(_name)
+	ret := make([]rune, 0, len(name))
+	for _, r := range name {
+		if unicode.IsSpace(r) || r == ':' {
+			continue
+		}
+		ret = append(ret, r)
+	}
+	return string(name)
+}
+
 func uniquefyNodesName(nodes []*node) {
 	// Uniquefy names of nodes.
 	// Sort nodes by "has node.Tag" because node.Tag is unique but names of others may be the same with them.
@@ -159,7 +173,7 @@ func uniquefyNodesName(nodes []*node) {
 		if node.dbNode.Tag != nil {
 			nameToNodes[*node.dbNode.Tag] = node
 		} else {
-			baseName := node.dbNode.Name
+			baseName := normNodeName(node.dbNode.Name)
 			if node.dbNode.SubscriptionID != nil {
 				baseName = fmt.Sprintf("%v.%v", *node.dbNode.SubscriptionID, baseName)
 			}
@@ -349,19 +363,20 @@ func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
 	nodes = deduplicateNodes(nodes)
 	uniquefyNodesName(nodes)
 	// Group -> nodes
-	mGroupNode := make(map[*db.Group][]*node)
-	for _, node := range nodes {
-		for _, group := range node.groups {
-			mGroupNode[group] = append(mGroupNode[group], node)
-		}
-	}
+	mGroupNode := make(map[*db.Group]map[*node]struct{})
 	for i := range groups {
-		if _, ok := mGroupNode[&groups[i]]; !ok {
-			mGroupNode[&groups[i]] = nil
+		mGroupNode[&groups[i]] = make(map[*node]struct{})
+	}
+	for _, n := range nodes {
+		for _, group := range n.groups {
+			mGroupNode[group][n] = struct{}{}
 		}
 	}
 	// Fill in group section.
-	for g, nodes := range mGroupNode {
+	for g, sNodes := range mGroupNode {
+		if len(sNodes) == 0 {
+			return 0, fmt.Errorf("please add at least one node into group '%v' (referenced by current routing '%v')", g.Name, mRouting.Name)
+		}
 		// Parse policy.
 		var policy daeConfig.FunctionListOrString
 		if len(g.PolicyParams) == 0 {
@@ -380,7 +395,7 @@ func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
 		}
 		// Node names to filter.
 		var names []*config_parser.Param
-		for _, node := range nodes {
+		for node := range sNodes {
 			names = append(names, &config_parser.Param{
 				Val: node.uniqueName,
 			})

--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -154,7 +154,7 @@ func normNodeName(_name string) string {
 	ret := make([]rune, 0, len(name))
 	for _, r := range name {
 		if unicode.IsSpace(r) || r == ':' {
-			continue
+			r = '_'
 		}
 		ret = append(ret, r)
 	}

--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"unicode"
 
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/dae"
@@ -153,12 +152,12 @@ func normNodeName(_name string) string {
 	name := []rune(_name)
 	ret := make([]rune, 0, len(name))
 	for _, r := range name {
-		if unicode.IsSpace(r) || r == ':' {
+		if r == ':' || r == '\'' {
 			r = '_'
 		}
 		ret = append(ret, r)
 	}
-	return string(name)
+	return string(ret)
 }
 
 func uniquefyNodesName(nodes []*node) {


### PR DESCRIPTION
## Background

1. If colons are in node names, dae throws an error.
   
   <img width="428" alt="图片" src="https://github.com/daeuniverse/dae-wing/assets/30586220/c606c818-0373-4785-9c5e-27efd1ae7713">

3. Node names can be duplicated in `filter` in some cases.
   
   ![图片](https://github.com/daeuniverse/dae-wing/assets/30586220/d76224ef-312c-491a-a22a-5fbfaa404f13)

5. dae-wing incorrectly accepts the situation that no node in the group.


## Changes

1. Replace any `'` and `:` with `_` from node names when starting to run.
2. Remove duplicated nodes in a group.
3. Response with an error if there is any group without a node.