### PR TITLE
fix: removing node and updating/removing subscription should update reloading version

### DIFF
--- a/graphql/service/node/mutation_utils.go
+++ b/graphql/service/node/mutation_utils.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/db"
 	"github.com/daeuniverse/dae-wing/graphql/internal"
@@ -85,11 +86,12 @@ func autoUpdateVersionByIds(d *gorm.DB, ids []uint) (err error) {
 		return nil
 	}
 
-	if err = d.Raw(`update groups
-                set groups.version = groups.version + 1
-                from groups
+	if err = d.Exec(`update groups
+                set version = groups.version + 1
+                from groups g
                     inner join group_nodes
-                    on groups.system_id = ? and groups.id = group_nodes.group_id and group_nodes.node_id in ?`, sys.ID, ids).Error; err != nil {
+                    on g.system_id = ? and g.id = group_nodes.group_id and group_nodes.node_id in ?
+				where g.id = groups.id`, sys.ID, ids).Error; err != nil {
 		return err
 	}
 

--- a/graphql/service/subscription/mutation_utils.go
+++ b/graphql/service/subscription/mutation_utils.go
@@ -134,11 +134,12 @@ func autoUpdateVersionByIds(d *gorm.DB, ids []uint) (err error) {
 		return nil
 	}
 
-	if err = d.Raw(`update groups
-                set groups.version = groups.version + 1
-                from groups
+	if err = d.Exec(`update groups
+                set version = groups.version + 1
+                from groups g
                     inner join group_subscriptions
-                    on groups.system_id = ? and groups.id = group_subscriptions.group_id and group_subscriptions.subscription_id in ?`, sys.ID, ids).Error; err != nil {
+                    on g.system_id = ? and g.id = group_subscriptions.group_id and group_subscriptions.subscription_id in ?
+				where g.id = groups.id`, sys.ID, ids).Error; err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Background

Updating/removing subscriptions and removing nodes (instead of `unlinking` from groups) in selected groups do not trigger `reload` showing in daed.

## Changes

Fix it.