### PR TITLE
fix: building problem caused by new group filter format

### DIFF
--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -402,11 +402,11 @@ func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
 		}
 		c.Group = append(c.Group, daeConfig.Group{
 			Name: g.Name,
-			Filter: []*config_parser.Function{{
+			Filter: [][]*config_parser.Function{{{
 				Name:   "name",
 				Not:    false,
 				Params: names,
-			}},
+			}}},
 			Policy: policy,
 		})
 	}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

```
$ go build .
# github.com/daeuniverse/dae-wing/graphql/service/config
graphql/service/config/mutation_utils.go:405:12: cannot use []*config_parser.Function{…} (value of type []*config_parser.Function) as [][]*config_parser.Function value in struct literal
```

This problem was caused by #64.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

