### PR TITLE
fix(Makefile): gzip unexpected filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,12 @@ bundle: deps
 		rm -r webrender/web 2>/dev/null; \
 		cp -r $(WEB_DIST) webrender/web; \
 		find webrender/web -type f -size +4k ! -name "*.gz" ! -name "*.woff"  ! -name "*.woff2" -exec sh -c '\
-			gzip -9 -k '{}'; \
-			if [ "$$(stat -c %s {})" \< "$$(stat -c %s {}.gz)" ]; then \
-				rm {}.gz; \
+			echo "{}"; \
+			gzip -9 -k "{}"; \
+			if [ $$(stat -c %s "{}") \< $$(stat -c %s "{}".gz) ]; then \
+				rm "{}".gz; \
 			else \
-				rm {}; \
+				rm "{}"; \
 			fi' ';' ; \
 	fi && \
 	go build -tags=embedallowed -o $(OUTPUT) -trimpath -ldflags $(LDFLAGS) .


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="459" alt="image" src="https://github.com/daeuniverse/dae-wing/assets/30586220/9373996d-cb2e-44ec-ba8f-ef1e8c2c6deb">

Fix that `make bundle` gives some warnings.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae
