### PR TITLE
chore: amd64 and arm64 use PIE build mode by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ APPNAME ?= dae-wing
 DESCRIPTION ?= $(APPNAME) is a integration solution of dae, API and UI.
 VERSION ?= 0.0.0.unknown
 LDFLAGS := '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=$(VERSION) -X github.com/daeuniverse/dae-wing/db.AppName=$(APPNAME) -X "github.com/daeuniverse/dae-wing/db.AppDescription=$(DESCRIPTION)" $(LDFLAGS)'
+GOARCH ?= $(shell go env GOARCH)
 
 include functions.mk
 
@@ -21,7 +22,12 @@ else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
 
-BUILD_ARGS := -trimpath -ldflags $(LDFLAGS) $(BUILD_ARGS)
+# amd64 and arm64 use PIE build mode by default
+ifeq ($(GOARCH),$(filter $(GOARCH),amd64 arm64))
+    BUILD_MODE ?= -buildmode=pie
+endif
+
+BUILD_ARGS := -trimpath -ldflags $(LDFLAGS) $(BUILD_MODE) $(BUILD_ARGS)
 
 # Do NOT remove the line below. This line is for CI.
 #export GOMODCACHE=$(PWD)/go-mod
@@ -70,7 +76,7 @@ bundle: deps
 				rm "{}"; \
 			fi' ';' ; \
 	fi && \
-	go build -tags=embedallowed -o $(OUTPUT) -trimpath -buildmode=pie -ldflags $(LDFLAGS) .
+	go build -tags=embedallowed -o $(OUTPUT) -trimpath -ldflags $(LDFLAGS) $(BUILD_MODE) .
 .PHONY: bundle
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,12 @@ endif
 
 # amd64 and arm64 use PIE build mode by default
 ifeq ($(GOARCH),$(filter $(GOARCH),amd64 arm64))
-    BUILD_MODE ?= -buildmode=pie
+	BUILD_MODE ?= pie
+else
+	BUILD_MODE ?= default
 endif
 
-BUILD_ARGS := -trimpath -ldflags $(GO_LDFLAGS) $(BUILD_MODE) $(BUILD_ARGS)
+BUILD_ARGS := -trimpath -ldflags $(GO_LDFLAGS) -buildmode=$(BUILD_MODE) $(BUILD_ARGS)
 
 # Do NOT remove the line below. This line is for CI.
 #export GOMODCACHE=$(PWD)/go-mod


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Usage:
``````shell
make BUILD_MODE='-buildmode=(build mode)'
# or
BUILD_MODE='-buildmode=(build mode)' make
``````

### Added the feature of setting BUILD_MODE according to GOARCH in Makefile

I added some code in Makefile to set different BUILD_MODE values  according to different GOARCH values, so as to achieve cross-platform  compilation and position-independent executable files. This allows the  program to run on different operating systems and computing  architectures, and also improves the security of the program. This PR is to enhance the compatibility and stability of the project.

I specifically specified that only when GOARCH is amd64 or arm64,  -buildmode=pie will be used to set BUILD_MODE. This is because pie may  not be supported on other computing architectures. Therefore, I used an  ifeq statement to judge the value of GOARCH and set BUILD_MODE according to different situations.

I also added a feature that allows users to manually specify the  build mode using make BUILD_MODE=-buildmode=*, overriding the default  settings. This allows users to choose the appropriate build mode  according to their needs, such as , pie, c-shared, c-archive,  shared, plugin, etc. If the user does not manually specify the build  mode, then if GOARCH is amd64 or arm64, -buildmode=pie will be used.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae-wing

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #_[issue number]_

### Test Result

I used different GOARCH and BUILD_MODE values to compile the project  and run tests on amd64 and arm64 platforms. The test results show that  my modification can correctly set BUILD_MODE and does not affect the  normal operation of other parameters and functions. 

**test code:**

``````shell
#!/bin/bash

make
echo ""
echo ""

for arch in 386 amd64 arm arm64 mips mips64 mips64le mipsle; do
        echo "===================$arch=========================="
        make GOARCH=$arch
        echo ""
        echo "============$arch Test Set BUILD_MODE============="
        make VERSION=$arch BUILD_MODE=-buildmode=exe
        echo ""


done
``````

**result:**

``````shell
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=pie  .


===================386==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." '   .

============386 Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=386 -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .

===================amd64==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=pie  .

============amd64 Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=amd64 -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .

===================arm==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." '   .

============arm Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=arm -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .

===================arm64==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=pie  .

============arm64 Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=arm64 -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .

===================mips==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." '   .

============mips Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=mips -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .

===================mips64==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." '   .

============mips64 Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=mips64 -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .

===================mips64le==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." '   .

============mips64le Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=mips64le -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .

===================mipsle==========================
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=0.0.0.unknown -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." '   .

============mipsle Test Set BUILD_MODE=============
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
WARN[0000] dangerous converting: may exceeds graphQL int32 range  name=SoMarkFromDae type=uint32
go build -o ./dae-wing -trimpath -ldflags '-s -w -X github.com/daeuniverse/dae-wing/db.AppVersion=mipsle -X github.com/daeuniverse/dae-wing/db.AppName=dae-wing -X "github.com/daeuniverse/dae-wing/db.AppDescription=dae-wing is a integration solution of dae, API and UI." ' -buildmode=exe  .
``````

<!--- Attach test result here. -->
