### PR TITLE
ci/hotfix(makefile): completely demise buildarg=pie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,6 @@ else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
 
-# amd64 and arm64 use PIE build mode by default
-ifeq ($(GOARCH),$(filter $(GOARCH),amd64 arm64))
-	BUILD_MODE ?= pie
-else
-	BUILD_MODE ?= default
-endif
-
 BUILD_ARGS := -trimpath -ldflags=$(GO_LDFLAGS) -buildmode=$(BUILD_MODE) $(BUILD_ARGS)
 
 # Do NOT remove the line below. This line is for CI.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

If build with pie, cgo will never be disabled, then OpenWrt, Alpine Linux and other systems based on MUSL C will not load dae/dae-wing.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae-wing

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #_[issue number]_

### Test Result

<!--- Attach test result here. -->
