### PR TITLE
ci: add dependabot for gitsubmodules and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Use dependabot for auto-updating gitsubmodules and github-actions instead

See the example resulting PR at [here](https://github.com/daeuniverse/daed-revived-next/pull/20)

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae-wing

### Full Changelogs

- ci: add dependabot for gitsubmodules and github-actions

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

NA
