### PR TITLE
feat: support cmd command to reset to custom password

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -58,6 +58,8 @@ var (
 	disableTimestamp  bool
 	listen            string
 	apiOnly           bool
+	newUserPassword   string
+	userName          string
 
 	runCmd = &cobra.Command{
 		Use:   "run",


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->
### Background
https://github.com/daeuniverse/daed/issues/211 daed resetpass need to set custom password
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae-wing

### Full Changelogs

- feat: support cmd command to reset to custom password

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix [211](https://github.com/daeuniverse/daed/issues/211) daed resetpass need to set custom password

### Test Result
![image](https://github.com/daeuniverse/dae-wing/assets/20339490/f008ee0a-27b4-4c53-9aea-663add3cd275)

<!--- Attach test result here. -->
