### PR TITLE
fix(graphql): correct syntax for `general` and `user` fields

### DIFF
--- a/graphql/root_schema.go
+++ b/graphql/root_schema.go
@@ -29,7 +29,7 @@ type Query {
 	numberUsers: Int!
 	# jsonStorage get given paths from user related json storage. Empty paths is to get all. Refer to https://github.com/tidwall/gjson
 	jsonStorage(paths: [String!]): [String!]! @hasRole(role: ADMIN)
-    user(): User! @hasRole(role: ADMIN)
+    user: User! @hasRole(role: ADMIN)
 	configFlatDesc: [ConfigFlatDesc!]! @hasRole(role: ADMIN)
 	configs(id: ID, selected: Boolean): [Config!]! @hasRole(role: ADMIN)
 	dnss(id: ID, selected: Boolean): [Dns!]! @hasRole(role: ADMIN)
@@ -40,7 +40,7 @@ type Query {
 	groups(id: ID): [Group!]! @hasRole(role: ADMIN)
 	group(name: String!): Group! @hasRole(role: ADMIN)
 	nodes(id: ID, subscriptionId: ID, first: Int, after: ID): NodesConnection! @hasRole(role: ADMIN)
-	general(): General! @hasRole(role: ADMIN)
+	general: General! @hasRole(role: ADMIN)
 }
 type Mutation {
 	# createUser creates a user if there is no user.
@@ -145,7 +145,7 @@ type Mutation {
 	removeGroup(id: ID!): Int! @hasRole(role: ADMIN)
 }
 enum Role {
-	admin
+	ADMIN
 }
 input ImportArgument {
 	link: String!


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
```bash
➜  daed git:(add_field) ✗ npx graphql-code-generator --config codegen.ts
✔ Parse Configuration
⚠ Generate outputs
  ❯ Generate to src/schemas/gql/
    ✖
      Failed to load schema from /home/wano/workspace/daeuniverse/daed/wing/schema.graphql:
      Syntax Error: Expected Name, found ")".
      GraphQLError: Syntax Error: Expected Name, found ")".
 ```
### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae-wing

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #_[issue number]_

### Test Result

<!--- Attach test result here. -->
