### PR TITLE
feat(group): support regex-filtered subscription bindings

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -44,6 +44,7 @@ func InitDatabase(configDir string) (err error) {
 		&Node{},
 		&Subscription{},
 		&Group{},
+		&GroupSubscription{},
 		&GroupPolicyParam{},
 		&System{},
 	); err != nil {

--- a/db/group.go
+++ b/db/group.go
@@ -14,11 +14,24 @@ type Group struct {
 	Name         string `gorm:"not null;unique;index"`
 	Policy       string `gorm:"not null"`
 	PolicyParams []GroupPolicyParam
-	Node         []Node         `gorm:"many2many:group_nodes;"`
-	Subscription []Subscription `gorm:"many2many:group_subscriptions;"`
+	Node         []Node              `gorm:"many2many:group_nodes;"`
+	SubscriptionBindings []GroupSubscription `gorm:"foreignKey:GroupID"`
 
 	Version  uint `gorm:"not null;default:0"`
 	SystemID *uint
+}
+
+type GroupSubscription struct {
+	GroupID         uint   `gorm:"primaryKey;autoIncrement:false"`
+	SubscriptionID  uint   `gorm:"primaryKey;autoIncrement:false"`
+	NameFilterRegex *string
+
+	Group        Group
+	Subscription Subscription
+}
+
+func (GroupSubscription) TableName() string {
+	return "group_subscriptions"
 }
 
 type GroupPolicyParam struct {

--- a/graphql/mutation.go
+++ b/graphql/mutation.go
@@ -508,8 +508,9 @@ func (r *MutationResolver) RenameGroup(args *struct {
 func (r *MutationResolver) GroupAddSubscriptions(args *struct {
 	ID              graphql.ID
 	SubscriptionIDs []graphql.ID
+	NameFilterRegex *string
 }) (int32, error) {
-	return group.AddSubscriptions(context.TODO(), args.ID, args.SubscriptionIDs)
+	return group.AddSubscriptions(context.TODO(), args.ID, args.SubscriptionIDs, args.NameFilterRegex)
 }
 
 func (r *MutationResolver) GroupDelSubscriptions(args *struct {

--- a/graphql/root_schema.go
+++ b/graphql/root_schema.go
@@ -132,8 +132,8 @@ type Mutation {
 	# groupSetPolicy is to set the group a new policy.
 	groupSetPolicy(id: ID!, policy: Policy!, policyParams: [PolicyParam!]): Int! @hasRole(role: ADMIN)
 
-	# groupAddSubscriptions is to add subscriptions to the group.
-	groupAddSubscriptions(id: ID!, subscriptionIDs: [ID!]!): Int! @hasRole(role: ADMIN)
+	# groupAddSubscriptions is to add subscriptions to the group, optionally with a shared name filter regex.
+	groupAddSubscriptions(id: ID!, subscriptionIDs: [ID!]!, nameFilterRegex: String): Int! @hasRole(role: ADMIN)
 
 	# groupDelSubscriptions is to remove subscriptions from the group.
 	groupDelSubscriptions(id: ID!, subscriptionIDs: [ID!]!): Int! @hasRole(role: ADMIN)

--- a/graphql/service/config/mutation_utils.go
+++ b/graphql/service/config/mutation_utils.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -128,6 +129,26 @@ type node struct {
 	dbNode     *db.Node
 	groups     []*db.Group
 	uniqueName string
+}
+
+func matchedNodesForGroupSubscription(binding *db.GroupSubscription) ([]db.Node, error) {
+	nodes := binding.Subscription.Node
+	if binding.NameFilterRegex == nil || *binding.NameFilterRegex == "" {
+		return nodes, nil
+	}
+
+	re, err := regexp.Compile(*binding.NameFilterRegex)
+	if err != nil {
+		return nil, err
+	}
+
+	var matched []db.Node
+	for _, n := range nodes {
+		if re.MatchString(n.Name) {
+			matched = append(matched, n)
+		}
+	}
+	return matched, nil
 }
 
 func deduplicateNodes(nodes []*node) []*node {
@@ -304,8 +325,9 @@ func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
 	q = d.Model(&db.Group{}).
 		Where("name in ?", outbounds).
 		Preload("PolicyParams").
-		Preload("Subscription").
-		Preload("Subscription.Node").
+		Preload("SubscriptionBindings").
+		Preload("SubscriptionBindings.Subscription").
+		Preload("SubscriptionBindings.Subscription.Node").
 		Find(&groups)
 	if q.Error != nil {
 		return 0, q.Error
@@ -336,8 +358,16 @@ func Run(d *gorm.DB, noLoad bool) (n int32, err error) {
 	// Find nodes in groups.
 	var nodes []*node
 	for i := range groups {
-		for _, gsub := range groups[i].Subscription {
-			for _, n := range gsub.Node {
+		for _, binding := range groups[i].SubscriptionBindings {
+			matchedNodes, err := matchedNodesForGroupSubscription(&binding)
+			if err != nil {
+				subscriptionName := binding.Subscription.Link
+				if binding.Subscription.Tag != nil && *binding.Subscription.Tag != "" {
+					subscriptionName = *binding.Subscription.Tag
+				}
+				return 0, fmt.Errorf("group '%v' has invalid subscription regex for '%v': %w", groups[i].Name, subscriptionName, err)
+			}
+			for _, n := range matchedNodes {
 				n := n
 				nodes = append(nodes, &node{
 					dbNode: &n,

--- a/graphql/service/group/mutation_utils.go
+++ b/graphql/service/group/mutation_utils.go
@@ -7,6 +7,9 @@ package group
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"strings"
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/db"
 	"github.com/daeuniverse/dae/pkg/config_parser"
@@ -40,6 +43,23 @@ func Create(ctx context.Context, name string, policy string, policyParams []conf
 func autoUpdateVersionById(d *gorm.DB, id uint) (err error) {
 	return d.Model(db.Group{ID: id}).
 		Update("version", gorm.Expr("version + 1")).Error
+}
+
+func normalizeNameFilterRegex(nameFilterRegex *string) (*string, error) {
+	if nameFilterRegex == nil {
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(*nameFilterRegex)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	if _, err := regexp.Compile(trimmed); err != nil {
+		return nil, fmt.Errorf("invalid name filter regex: %w", err)
+	}
+
+	return &trimmed, nil
 }
 
 func Rename(ctx context.Context, _id graphql.ID, name string) (n int32, err error) {
@@ -99,7 +119,7 @@ func Remove(ctx context.Context, _id graphql.ID) (n int32, err error) {
 	if err = tx.Model(&db.Group{ID: id}).Association("Node").Clear(); err != nil {
 		return 0, err
 	}
-	if err = tx.Model(&db.Group{ID: id}).Association("Subscription").Clear(); err != nil {
+	if err = tx.Where("group_id = ?", id).Delete(&db.GroupSubscription{}).Error; err != nil {
 		return 0, err
 	}
 	if err = tx.Where("group_id = ?", id).Delete(&db.GroupPolicyParam{}).Error; err != nil {
@@ -111,7 +131,7 @@ func Remove(ctx context.Context, _id graphql.ID) (n int32, err error) {
 	return int32(q.RowsAffected), nil
 }
 
-func AddSubscriptions(ctx context.Context, _id graphql.ID, _subscriptionIds []graphql.ID) (int32, error) {
+func AddSubscriptions(ctx context.Context, _id graphql.ID, _subscriptionIds []graphql.ID, nameFilterRegex *string) (int32, error) {
 	id, err := common.DecodeCursor(_id)
 	if err != nil {
 		return 0, err
@@ -120,9 +140,17 @@ func AddSubscriptions(ctx context.Context, _id graphql.ID, _subscriptionIds []gr
 	if err != nil {
 		return 0, err
 	}
-	var subs []db.Subscription
-	for _, id := range subscriptionIds {
-		subs = append(subs, db.Subscription{ID: id})
+	normalizedRegex, err := normalizeNameFilterRegex(nameFilterRegex)
+	if err != nil {
+		return 0, err
+	}
+	var bindings []db.GroupSubscription
+	for _, subscriptionId := range subscriptionIds {
+		bindings = append(bindings, db.GroupSubscription{
+			GroupID:         id,
+			SubscriptionID:  subscriptionId,
+			NameFilterRegex: normalizedRegex,
+		})
 	}
 	tx := db.BeginTx(ctx)
 	defer func() {
@@ -132,10 +160,15 @@ func AddSubscriptions(ctx context.Context, _id graphql.ID, _subscriptionIds []gr
 			tx.Rollback()
 		}
 	}()
-	if err = tx.Model(&db.Group{ID: id}).
-		Association("Subscription").
-		Append(subs); err != nil {
-		return 0, err
+	if len(bindings) > 0 {
+		if err = tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "group_id"}, {Name: "subscription_id"}},
+			DoUpdates: clause.Assignments(map[string]interface{}{
+				"name_filter_regex": normalizedRegex,
+			}),
+		}).Create(&bindings).Error; err != nil {
+			return 0, err
+		}
 	}
 
 	if err = autoUpdateVersionById(tx, id); err != nil {
@@ -153,10 +186,6 @@ func DelSubscriptions(ctx context.Context, _id graphql.ID, _subscriptionIds []gr
 	if err != nil {
 		return 0, err
 	}
-	var subs []db.Subscription
-	for _, id := range subscriptionIds {
-		subs = append(subs, db.Subscription{ID: id})
-	}
 	tx := db.BeginTx(ctx)
 	defer func() {
 		if err == nil {
@@ -165,9 +194,8 @@ func DelSubscriptions(ctx context.Context, _id graphql.ID, _subscriptionIds []gr
 			tx.Rollback()
 		}
 	}()
-	if err = tx.Model(&db.Group{ID: id}).
-		Association("Subscription").
-		Delete(subs); err != nil {
+	if err = tx.Where("group_id = ? AND subscription_id in ?", id, subscriptionIds).
+		Delete(&db.GroupSubscription{}).Error; err != nil {
 		return 0, err
 	}
 

--- a/graphql/service/group/resolver.go
+++ b/graphql/service/group/resolver.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	"context"
+	"regexp"
 	"github.com/daeuniverse/dae-wing/common"
 	"github.com/daeuniverse/dae-wing/db"
 	"github.com/daeuniverse/dae-wing/graphql/internal"
@@ -12,6 +13,10 @@ import (
 
 type Resolver struct {
 	*db.Group
+}
+
+type SubscriptionBindingResolver struct {
+	*db.GroupSubscription
 }
 
 func (r *Resolver) ID() graphql.ID {
@@ -34,14 +39,38 @@ func (r *Resolver) Nodes() (rs []*node.Resolver, err error) {
 	return rs, nil
 }
 
-func (r *Resolver) Subscriptions() (rs []*subscription.Resolver, err error) {
-	var subs []db.Subscription
-	if err = db.DB(context.TODO()).Model(r.Group).Association("Subscription").Find(&subs); err != nil {
+func matchedNodesForBinding(binding *db.GroupSubscription) ([]db.Node, error) {
+	nodes := binding.Subscription.Node
+	if binding.NameFilterRegex == nil || *binding.NameFilterRegex == "" {
+		return nodes, nil
+	}
+
+	re, err := regexp.Compile(*binding.NameFilterRegex)
+	if err != nil {
 		return nil, err
 	}
-	for _, _n := range subs {
-		n := _n
-		rs = append(rs, &subscription.Resolver{Subscription: &n})
+
+	var matched []db.Node
+	for _, n := range nodes {
+		if re.MatchString(n.Name) {
+			matched = append(matched, n)
+		}
+	}
+	return matched, nil
+}
+
+func (r *Resolver) Subscriptions() (rs []*SubscriptionBindingResolver, err error) {
+	var bindings []db.GroupSubscription
+	if err = db.DB(context.TODO()).
+		Where("group_id = ?", r.Group.ID).
+		Preload("Subscription").
+		Preload("Subscription.Node").
+		Find(&bindings).Error; err != nil {
+		return nil, err
+	}
+	for _, _binding := range bindings {
+		binding := _binding
+		rs = append(rs, &SubscriptionBindingResolver{GroupSubscription: &binding})
 	}
 	return rs, nil
 }
@@ -59,4 +88,33 @@ func (r *Resolver) PolicyParams() (rs []*internal.ParamResolver, err error) {
 		rs = append(rs, &internal.ParamResolver{Param: param.Marshal()})
 	}
 	return rs, nil
+}
+
+func (r *SubscriptionBindingResolver) Subscription() *subscription.Resolver {
+	sub := r.GroupSubscription.Subscription
+	return &subscription.Resolver{Subscription: &sub}
+}
+
+func (r *SubscriptionBindingResolver) NameFilterRegex() *string {
+	return r.GroupSubscription.NameFilterRegex
+}
+
+func (r *SubscriptionBindingResolver) MatchedNodes() (rs []*node.Resolver, err error) {
+	matched, err := matchedNodesForBinding(r.GroupSubscription)
+	if err != nil {
+		return nil, err
+	}
+	for _, _node := range matched {
+		n := _node
+		rs = append(rs, &node.Resolver{Node: &n})
+	}
+	return rs, nil
+}
+
+func (r *SubscriptionBindingResolver) MatchedCount() (int32, error) {
+	matched, err := matchedNodesForBinding(r.GroupSubscription)
+	if err != nil {
+		return 0, err
+	}
+	return int32(len(matched)), nil
 }

--- a/graphql/service/group/schema.go
+++ b/graphql/service/group/schema.go
@@ -7,11 +7,18 @@ package group
 
 func Schema() (string, error) {
 	return `
+type GroupSubscription {
+	subscription: Subscription!
+	nameFilterRegex: String
+	matchedNodes: [Node!]!
+	matchedCount: Int!
+}
+
 type Group {
 	id: ID!
 	name: String!
 	nodes: [Node!]!
-	subscriptions: [Subscription!]!
+	subscriptions: [GroupSubscription!]!
 	policy: Policy!
 	policyParams: [Param!]!
 }

--- a/graphql/service/subscription/mutation_utils.go
+++ b/graphql/service/subscription/mutation_utils.go
@@ -359,6 +359,10 @@ func Remove(ctx context.Context, _ids []graphql.ID) (n int32, err error) {
 		Delete(&db.Node{}).Error; err != nil {
 		return 0, err
 	}
+	if err = tx.Where("subscription_id in ?", ids).
+		Delete(&db.GroupSubscription{}).Error; err != nil {
+		return 0, err
+	}
 	q := tx.Where("id in ?", ids).
 		Select(clause.Associations).
 		Delete(&db.Subscription{})


### PR DESCRIPTION
## Summary

This PR adds regex-aware subscription bindings for groups.

Instead of treating a group-to-subscription relation as a plain many-to-many link, a group can now bind a subscription together with an optional node-name regex. This allows consumers such as `daed` to attach a subscription to a group in either:

- full subscription mode
- filtered subscription mode

## What changed

- add `GroupSubscription` binding metadata on top of `group_subscriptions`
- support optional `nameFilterRegex` for each group/subscription binding
- expose group subscription bindings through GraphQL instead of returning bare subscriptions
- extend `groupAddSubscriptions` with optional `nameFilterRegex`
- resolve matched nodes for a binding by filtering subscription nodes by node name
- apply the filtered binding result when generating runtime config
- remove related group subscription bindings when subscriptions are deleted

## Behavior

- if `nameFilterRegex` is empty or null, the whole subscription is used
- if `nameFilterRegex` is present, only subscription nodes whose `name` matches the regex are included
- invalid regex input is rejected when creating/updating the binding
- runtime config generation uses the currently matched node set instead of always expanding the full subscription

## Why

This is intended to support a UI flow where users can add subscription groups to a group and optionally provide a node-name regex to keep only the nodes they want.

This is a `dae-wing`-side binding capability and does not try to change `dae-core` native group filter semantics.

## Notes

- this PR does not add a new `dae-core` filter syntax
- this PR keeps manual group nodes and subscription-derived nodes conceptually separate at the binding layer
- downstream UI can use:
  - `subscription`
  - `nameFilterRegex`
  - `matchedNodes`
  - `matchedCount`
  to preview what a binding will contribute

## Manual verification

- [ ] add a subscription to a group without regex and confirm all subscription nodes are included
- [ ] add a subscription to a group with regex and confirm only matched nodes are included
- [ ] update a subscription and confirm the matched result changes accordingly
- [ ] remove a subscription and confirm related binding rows are cleaned up
- [ ] run with a config referencing the group and confirm filtered nodes are used

## Related

This is intended to be consumed by a follow-up `daed` UI change for regex-filtered group subscription selection.
