### PR TITLE
feat(graphql): expose runtime traffic overview and node latency APIs

### DIFF
--- a/dae/runtime.go
+++ b/dae/runtime.go
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2023, daeuniverse Organization <team@v2raya.org>
+ */
+
+package dae
+
+import (
+	"errors"
+	"time"
+
+	"github.com/daeuniverse/dae/control"
+)
+
+type RuntimeTrafficSample struct {
+	Timestamp    time.Time
+	UploadRate   uint64
+	DownloadRate uint64
+}
+
+type RuntimeOverview struct {
+	UpdatedAt         time.Time
+	UploadRate        uint64
+	DownloadRate      uint64
+	UploadTotal       uint64
+	DownloadTotal     uint64
+	ActiveConnections int
+	UDPSessions       int
+	Samples           []RuntimeTrafficSample
+}
+
+func GetRuntimeOverview(windowSec int, maxPoints int) (*RuntimeOverview, error) {
+	activeTCPConnections := 0
+	ctl, err := ControlPlane()
+	if err != nil {
+		if !errors.Is(err, ErrControlPlaneNotInit) {
+			return nil, err
+		}
+	} else {
+		activeTCPConnections = ctl.ActiveTCPConnections()
+	}
+
+	snapshot := control.SnapshotRuntimeStats(activeTCPConnections, control.DefaultUdpEndpointPool.Count(), windowSec, maxPoints)
+
+	samples := make([]RuntimeTrafficSample, 0, len(snapshot.Samples))
+	for _, sample := range snapshot.Samples {
+		samples = append(samples, RuntimeTrafficSample{
+			Timestamp:    sample.Timestamp,
+			UploadRate:   sample.UploadRate,
+			DownloadRate: sample.DownloadRate,
+		})
+	}
+
+	return &RuntimeOverview{
+		UpdatedAt:         snapshot.UpdatedAt,
+		UploadRate:        snapshot.UploadRate,
+		DownloadRate:      snapshot.DownloadRate,
+		UploadTotal:       snapshot.UploadTotal,
+		DownloadTotal:     snapshot.DownloadTotal,
+		ActiveConnections: snapshot.ActiveConnections,
+		UDPSessions:       snapshot.UDPSessions,
+		Samples:           samples,
+	}, nil
+}

--- a/graphql/mutation.go
+++ b/graphql/mutation.go
@@ -374,6 +374,12 @@ func (r *MutationResolver) UpdateNode(args *struct {
 	return result, nil
 }
 
+func (r *MutationResolver) TestNodeLatencies(args *struct {
+	IDs *[]graphql.ID
+}) ([]*node.LatencyResolver, error) {
+	return node.TestLatencies(context.TODO(), args.IDs)
+}
+
 func (r *MutationResolver) RemoveNodes(args *struct {
 	IDs []graphql.ID
 }) (int32, error) {

--- a/graphql/query.go
+++ b/graphql/query.go
@@ -147,6 +147,13 @@ func (r *queryResolver) General() (*general.Resolver, error) {
 		GraphqlSchema: schema,
 	}, nil
 }
+
+func (r *queryResolver) NodeLatencies(ctx context.Context, args *struct {
+	IDs *[]graphql.ID
+}) ([]*node.LatencyResolver, error) {
+	return node.QueryLatencies(ctx, args.IDs)
+}
+
 func (r *queryResolver) Configs(args *struct {
 	ID       *graphql.ID
 	Selected *bool

--- a/graphql/root_schema.go
+++ b/graphql/root_schema.go
@@ -102,6 +102,9 @@ type Mutation {
 	# updateNode is to update a node with no subscription ID.
 	updateNode(id: ID!, newLink: String!): Node! @hasRole(role: ADMIN)
 
+	# testNodeLatencies is to trigger latency probes for all or selected nodes.
+	testNodeLatencies(ids: [ID!]): [NodeLatency!]! @hasRole(role: ADMIN)
+
 	# removeNodes is to remove nodes that have no subscription ID.
 	removeNodes(ids: [ID!]!): Int! @hasRole(role: ADMIN)
 

--- a/graphql/root_schema.go
+++ b/graphql/root_schema.go
@@ -40,6 +40,7 @@ type Query {
 	groups(id: ID): [Group!]! @hasRole(role: ADMIN)
 	group(name: String!): Group! @hasRole(role: ADMIN)
 	nodes(id: ID, subscriptionId: ID, first: Int, after: ID): NodesConnection! @hasRole(role: ADMIN)
+	nodeLatencies(ids: [ID!]): [NodeLatency!]! @hasRole(role: ADMIN)
 	general: General! @hasRole(role: ADMIN)
 }
 type Mutation {

--- a/graphql/service/general/runtime_resolver.go
+++ b/graphql/service/general/runtime_resolver.go
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2023, daeuniverse Organization <team@v2raya.org>
+ */
+
+package general
+
+import (
+	"strconv"
+
+	"github.com/daeuniverse/dae-wing/dae"
+	"github.com/graph-gophers/graphql-go"
+)
+
+type RuntimeOverviewResolver struct {
+	Overview *dae.RuntimeOverview
+}
+
+type RuntimeTrafficSampleResolver struct {
+	Sample dae.RuntimeTrafficSample
+}
+
+func (r *Resolver) RuntimeOverview(args *struct {
+	WindowSec int32
+	MaxPoints int32
+}) (*RuntimeOverviewResolver, error) {
+	overview, err := dae.GetRuntimeOverview(int(args.WindowSec), int(args.MaxPoints))
+	if err != nil {
+		return nil, err
+	}
+	return &RuntimeOverviewResolver{Overview: overview}, nil
+}
+
+func (r *RuntimeOverviewResolver) UpdatedAt() graphql.Time {
+	return graphql.Time{Time: r.Overview.UpdatedAt}
+}
+
+func (r *RuntimeOverviewResolver) UploadRate() float64 {
+	return float64(r.Overview.UploadRate)
+}
+
+func (r *RuntimeOverviewResolver) DownloadRate() float64 {
+	return float64(r.Overview.DownloadRate)
+}
+
+func (r *RuntimeOverviewResolver) UploadTotal() string {
+	return strconv.FormatUint(r.Overview.UploadTotal, 10)
+}
+
+func (r *RuntimeOverviewResolver) DownloadTotal() string {
+	return strconv.FormatUint(r.Overview.DownloadTotal, 10)
+}
+
+func (r *RuntimeOverviewResolver) ActiveConnections() int32 {
+	return int32(r.Overview.ActiveConnections)
+}
+
+func (r *RuntimeOverviewResolver) UdpSessions() int32 {
+	return int32(r.Overview.UDPSessions)
+}
+
+func (r *RuntimeOverviewResolver) Samples() []*RuntimeTrafficSampleResolver {
+	resolvers := make([]*RuntimeTrafficSampleResolver, 0, len(r.Overview.Samples))
+	for _, sample := range r.Overview.Samples {
+		resolvers = append(resolvers, &RuntimeTrafficSampleResolver{Sample: sample})
+	}
+	return resolvers
+}
+
+func (r *RuntimeTrafficSampleResolver) Timestamp() graphql.Time {
+	return graphql.Time{Time: r.Sample.Timestamp}
+}
+
+func (r *RuntimeTrafficSampleResolver) UploadRate() float64 {
+	return float64(r.Sample.UploadRate)
+}
+
+func (r *RuntimeTrafficSampleResolver) DownloadRate() float64 {
+	return float64(r.Sample.DownloadRate)
+}

--- a/graphql/service/general/schema.go
+++ b/graphql/service/general/schema.go
@@ -10,6 +10,7 @@ func Schema() (string, error) {
 type General {
   dae: Dae!
   interfaces(up:Boolean): [Interface!]!
+  runtimeOverview(windowSec:Int!, maxPoints:Int!): RuntimeOverview!
   schema: String!
 }
 type Dae {
@@ -32,6 +33,21 @@ type DefaultRoute {
   ipVersion: String!
   gateway: String
   source: String
+}
+type RuntimeOverview {
+  updatedAt: Time!
+  uploadRate: Float!
+  downloadRate: Float!
+  uploadTotal: String!
+  downloadTotal: String!
+  activeConnections: Int!
+  udpSessions: Int!
+  samples: [RuntimeTrafficSample!]!
+}
+type RuntimeTrafficSample {
+  timestamp: Time!
+  uploadRate: Float!
+  downloadRate: Float!
 }
 `, nil
 }

--- a/graphql/service/node/latency_cache.go
+++ b/graphql/service/node/latency_cache.go
@@ -1,0 +1,233 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2023, daeuniverse Organization <team@v2raya.org>
+ */
+
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/daeuniverse/dae-wing/dae"
+	"github.com/daeuniverse/dae-wing/db"
+	"github.com/graph-gophers/graphql-go"
+)
+
+var nodeLatencyCache = struct {
+	mu          sync.RWMutex
+	refreshMu   sync.Mutex
+	updatedAt   time.Time
+	items       map[uint]*LatencyResolver
+}{
+	items: map[uint]*LatencyResolver{},
+}
+
+func cloneLatencyResolver(resolver *LatencyResolver) *LatencyResolver {
+	if resolver == nil {
+		return nil
+	}
+
+	clone := *resolver
+	if resolver.LatencyMsV != nil {
+		latency := *resolver.LatencyMsV
+		clone.LatencyMsV = &latency
+	}
+	if resolver.MessageV != nil {
+		message := *resolver.MessageV
+		clone.MessageV = &message
+	}
+	return &clone
+}
+
+func storeLatencyResults(results []*LatencyResolver) {
+	nodeLatencyCache.mu.Lock()
+	defer nodeLatencyCache.mu.Unlock()
+
+	nodeLatencyCache.updatedAt = time.Now()
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+		nodeLatencyCache.items[result.NodeID] = cloneLatencyResolver(result)
+	}
+}
+
+func snapshotCachedLatencyResults() map[uint]*LatencyResolver {
+	nodeLatencyCache.mu.RLock()
+	defer nodeLatencyCache.mu.RUnlock()
+
+	results := make(map[uint]*LatencyResolver, len(nodeLatencyCache.items))
+	for id, resolver := range nodeLatencyCache.items {
+		results[id] = cloneLatencyResolver(resolver)
+	}
+	return results
+}
+
+func lastLatencyCacheUpdatedAt() time.Time {
+	nodeLatencyCache.mu.RLock()
+	defer nodeLatencyCache.mu.RUnlock()
+	return nodeLatencyCache.updatedAt
+}
+
+func loadRuntimeLatencyResults(ctx context.Context) (map[uint]*LatencyResolver, error) {
+	ctl, err := dae.ControlPlane()
+	if err != nil {
+		if errors.Is(err, dae.ErrControlPlaneNotInit) {
+			return map[uint]*LatencyResolver{}, nil
+		}
+		return nil, err
+	}
+
+	snapshots := ctl.SnapshotNodeLatencies()
+	if len(snapshots) == 0 {
+		return map[uint]*LatencyResolver{}, nil
+	}
+
+	links := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		if snapshot.Link == "" {
+			continue
+		}
+		links = append(links, snapshot.Link)
+	}
+
+	if len(links) == 0 {
+		return map[uint]*LatencyResolver{}, nil
+	}
+
+	var nodes []db.Node
+	if err := db.DB(ctx).Where("link in ?", links).Find(&nodes).Error; err != nil {
+		return nil, err
+	}
+
+	nodeByLink := make(map[string]db.Node, len(nodes))
+	for _, node := range nodes {
+		nodeByLink[node.Link] = node
+	}
+
+	results := make(map[uint]*LatencyResolver)
+	for _, snapshot := range snapshots {
+		if snapshot.CheckedAt.IsZero() && snapshot.LatencyMs == nil && snapshot.Message == "no latency result" {
+			continue
+		}
+
+		node, ok := nodeByLink[snapshot.Link]
+		if !ok {
+			continue
+		}
+
+		results[node.ID] = cloneLatencyResolver(&LatencyResolver{
+			NodeID:     node.ID,
+			LatencyMsV: snapshot.LatencyMs,
+			AliveVal:   snapshot.Alive,
+			TestedAtV:  snapshot.CheckedAt,
+			MessageV:   stringPtr(snapshot.Message),
+		})
+	}
+
+	storeLatencyResults(mapsValues(results))
+	return results, nil
+}
+
+func selectedCheckInterval(ctx context.Context) (time.Duration, error) {
+	var configModel db.Config
+	if err := db.DB(ctx).Where("selected = ?", true).First(&configModel).Error; err != nil {
+		return 0, err
+	}
+
+	parsedConfig, err := dae.ParseConfig(&configModel.Global, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	if parsedConfig.Global.CheckInterval <= 0 {
+		return 30 * time.Second, nil
+	}
+
+	return parsedConfig.Global.CheckInterval, nil
+}
+
+func refreshLatencyCache(ctx context.Context) error {
+	option, err := latencyProbeOption(ctx)
+	if err != nil {
+		return err
+	}
+
+	nodes, err := latencyProbeNodes(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	results := testLatencyResultsForNodes(option, nodes)
+	storeLatencyResults(results)
+
+	if ctl, err := dae.ControlPlane(); err == nil {
+		ctl.TriggerLatencyChecks()
+	}
+
+	return nil
+}
+
+func refreshLatencyCacheIfNeeded(ctx context.Context) error {
+	interval, err := selectedCheckInterval(ctx)
+	if err != nil {
+		return err
+	}
+
+	lastUpdated := lastLatencyCacheUpdatedAt()
+	if !lastUpdated.IsZero() && time.Since(lastUpdated) < interval {
+		return nil
+	}
+
+	nodeLatencyCache.refreshMu.Lock()
+	defer nodeLatencyCache.refreshMu.Unlock()
+
+	lastUpdated = lastLatencyCacheUpdatedAt()
+	if !lastUpdated.IsZero() && time.Since(lastUpdated) < interval {
+		return nil
+	}
+
+	return refreshLatencyCache(ctx)
+}
+
+func mapsValues(items map[uint]*LatencyResolver) []*LatencyResolver {
+	results := make([]*LatencyResolver, 0, len(items))
+	for _, item := range items {
+		results = append(results, item)
+	}
+	return results
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func QueryLatencies(ctx context.Context, ids *[]graphql.ID) ([]*LatencyResolver, error) {
+	_ = refreshLatencyCacheIfNeeded(ctx)
+
+	nodes, err := latencyProbeNodes(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := snapshotCachedLatencyResults()
+	runtimeResults, err := loadRuntimeLatencyResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for id, resolver := range runtimeResults {
+		merged[id] = resolver
+	}
+
+	results := make([]*LatencyResolver, 0, len(nodes))
+	for _, node := range nodes {
+		if resolver, ok := merged[node.ID]; ok {
+			results = append(results, cloneLatencyResolver(resolver))
+		}
+	}
+
+	return results, nil
+}

--- a/graphql/service/node/latency_mutation_utils.go
+++ b/graphql/service/node/latency_mutation_utils.go
@@ -32,6 +32,12 @@ func TestLatencies(ctx context.Context, ids *[]graphql.ID) ([]*LatencyResolver, 
 		return nil, err
 	}
 
+	results := testLatencyResultsForNodes(option, nodes)
+	storeLatencyResults(results)
+	return results, nil
+}
+
+func testLatencyResultsForNodes(option *dialer.GlobalOption, nodes []db.Node) []*LatencyResolver {
 	results := make([]*LatencyResolver, len(nodes))
 	sem := make(chan struct{}, latencyProbeConcurrency)
 	var wg sync.WaitGroup
@@ -50,7 +56,7 @@ func TestLatencies(ctx context.Context, ids *[]graphql.ID) ([]*LatencyResolver, 
 	}
 
 	wg.Wait()
-	return results, nil
+	return results
 }
 
 func latencyProbeOption(ctx context.Context) (*dialer.GlobalOption, error) {

--- a/graphql/service/node/latency_mutation_utils.go
+++ b/graphql/service/node/latency_mutation_utils.go
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2023, daeuniverse Organization <team@v2raya.org>
+ */
+
+package node
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/daeuniverse/dae-wing/common"
+	"github.com/daeuniverse/dae-wing/dae"
+	"github.com/daeuniverse/dae-wing/db"
+	dialer "github.com/daeuniverse/dae/component/outbound/dialer"
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sirupsen/logrus"
+)
+
+const latencyProbeConcurrency = 8
+
+func TestLatencies(ctx context.Context, ids *[]graphql.ID) ([]*LatencyResolver, error) {
+	option, err := latencyProbeOption(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := latencyProbeNodes(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]*LatencyResolver, len(nodes))
+	sem := make(chan struct{}, latencyProbeConcurrency)
+	var wg sync.WaitGroup
+
+	for index := range nodes {
+		index := index
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			node := nodes[index]
+			results[index] = testSingleNodeLatency(option, &node)
+		}()
+	}
+
+	wg.Wait()
+	return results, nil
+}
+
+func latencyProbeOption(ctx context.Context) (*dialer.GlobalOption, error) {
+	var configModel db.Config
+	q := db.DB(ctx).Where("selected = ?", true).First(&configModel)
+	if q.Error != nil {
+		return nil, q.Error
+	}
+
+	parsedConfig, err := dae.ParseConfig(&configModel.Global, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	return dialer.NewGlobalOption(&parsedConfig.Global, log), nil
+}
+
+func latencyProbeNodes(ctx context.Context, ids *[]graphql.ID) ([]db.Node, error) {
+	q := db.DB(ctx).Model(&db.Node{})
+	if ids != nil {
+		decodedIDs, err := common.DecodeCursorBatch(*ids)
+		if err != nil {
+			return nil, err
+		}
+		q = q.Where("id in ?", decodedIDs)
+	}
+
+	var nodes []db.Node
+	if err := q.Find(&nodes).Error; err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}
+
+func testSingleNodeLatency(option *dialer.GlobalOption, node *db.Node) *LatencyResolver {
+	resolver := &LatencyResolver{
+		NodeID:    node.ID,
+		AliveVal:  false,
+		TestedAtV: time.Now(),
+	}
+
+	d, err := dialer.NewFromLink(option, dialer.InstanceOption{DisableCheck: false}, node.Link, "")
+	if err != nil {
+		msg := err.Error()
+		resolver.MessageV = &msg
+		return resolver
+	}
+	defer d.Close()
+
+	result, err := d.ProbeLatency()
+	if err != nil {
+		msg := err.Error()
+		resolver.MessageV = &msg
+		return resolver
+	}
+
+	resolver.AliveVal = result.Alive
+	resolver.TestedAtV = result.CheckedAt
+	if result.Alive {
+		latencyMs := int32(result.Latency.Milliseconds())
+		resolver.LatencyMsV = &latencyMs
+		return resolver
+	}
+	if result.Message != "" {
+		msg := result.Message
+		resolver.MessageV = &msg
+	}
+	return resolver
+}

--- a/graphql/service/node/latency_resolver.go
+++ b/graphql/service/node/latency_resolver.go
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2023, daeuniverse Organization <team@v2raya.org>
+ */
+
+package node
+
+import (
+	"time"
+
+	"github.com/daeuniverse/dae-wing/common"
+	"github.com/graph-gophers/graphql-go"
+)
+
+type LatencyResolver struct {
+	NodeID    uint
+	LatencyMsV *int32
+	AliveVal  bool
+	TestedAtV time.Time
+	MessageV  *string
+}
+
+func (r *LatencyResolver) ID() graphql.ID {
+	return common.EncodeCursor(r.NodeID)
+}
+
+func (r *LatencyResolver) LatencyMs() *int32 {
+	return r.LatencyMsV
+}
+
+func (r *LatencyResolver) Alive() bool {
+	return r.AliveVal
+}
+
+func (r *LatencyResolver) TestedAt() graphql.Time {
+	return graphql.Time{Time: r.TestedAtV}
+}
+
+func (r *LatencyResolver) Message() *string {
+	return r.MessageV
+}

--- a/graphql/service/node/schema.go
+++ b/graphql/service/node/schema.go
@@ -21,5 +21,12 @@ type NodesConnection {
 	edges: [Node!]!
 	pageInfo: PageInfo! 
 }
+type NodeLatency {
+	id: ID!
+	latencyMs: Int
+	alive: Boolean!
+	testedAt: Time!
+	message: String
+}
 `, nil
 }


### PR DESCRIPTION
## Summary

This PR exposes runtime traffic overview and node latency APIs in `dae-wing`.

It is intended to consume the runtime/control-plane capabilities that have already been added in `dae` and make them available to upper-layer UIs such as `daed`.

## What changed

- add `general.runtimeOverview(windowSec, maxPoints)`
- expose runtime traffic overview through GraphQL
- add `testNodeLatencies(ids)` mutation
- add `nodeLatencies(ids)` query
- add `NodeLatency` GraphQL type
- persist manual latency probe results in an in-memory cache
- merge cached results with runtime latency snapshots from the control plane

## Runtime traffic overview

This PR adds a GraphQL API for runtime traffic metrics.

New API:
- `general.runtimeOverview(windowSec, maxPoints)`

Returned fields include:
- `updatedAt`
- `uploadRate`
- `downloadRate`
- `uploadTotal`
- `downloadTotal`
- `activeConnections`
- `udpSessions`
- sampled traffic history for charting

## Node latency APIs

This PR adds GraphQL support for node latency probing and querying.

New API:
- `testNodeLatencies(ids)` mutation
- `nodeLatencies(ids)` query

Returned fields include:
- `id`
- `latencyMs`
- `alive`
- `testedAt`
- `message`

## Behavior

- manual latency tests store results in a cache
- latency query merges:
  - cached manual results
  - runtime latency snapshots from the running control plane
- latency cache refresh respects the selected config's `check_interval`
- if the control plane is not running, querying latencies still works through cached/manual probe results

## Dependency

This PR depends on the `dae` runtime/control-plane support that has already been added in:

- dae PR: <https://github.com/daeuniverse/dae/commit/39831d5d24a129ce8c53258e54cfe6cde1502529>

This `dae-wing` change is the API layer on top of that runtime capability.

## Why

These APIs are needed by upper-layer consumers to support:
- runtime traffic charts
- current upload/download rates
- active connection / UDP session statistics
- manual node latency testing
- latency display in node/subscription/group UIs

## Manual verification

- [ ] query `general.runtimeOverview` and confirm runtime traffic fields are returned
- [ ] verify sampled traffic history is returned for charting
- [ ] run `testNodeLatencies(ids)` and confirm results are returned
- [ ] query `nodeLatencies` after manual probing and confirm cached results are visible
- [ ] confirm runtime latency snapshots are surfaced when dae is running
- [ ] confirm behavior remains sane when control plane is not initialized
