### PR TITLE
fix(graphql): keep manual latency cache authoritative

### DIFF
--- a/graphql/service/node/latency_cache.go
+++ b/graphql/service/node/latency_cache.go
@@ -103,9 +103,9 @@ func loadRuntimeLatencyResults(ctx context.Context) (map[uint]*LatencyResolver, 
 		return nil, err
 	}
 
-	nodeByLink := make(map[string]db.Node, len(nodes))
+	nodesByLink := make(map[string][]db.Node, len(nodes))
 	for _, node := range nodes {
-		nodeByLink[node.Link] = node
+		nodesByLink[node.Link] = append(nodesByLink[node.Link], node)
 	}
 
 	results := make(map[uint]*LatencyResolver)
@@ -114,21 +114,22 @@ func loadRuntimeLatencyResults(ctx context.Context) (map[uint]*LatencyResolver, 
 			continue
 		}
 
-		node, ok := nodeByLink[snapshot.Link]
+		matchedNodes, ok := nodesByLink[snapshot.Link]
 		if !ok {
 			continue
 		}
 
-		results[node.ID] = cloneLatencyResolver(&LatencyResolver{
-			NodeID:     node.ID,
-			LatencyMsV: snapshot.LatencyMs,
-			AliveVal:   snapshot.Alive,
-			TestedAtV:  snapshot.CheckedAt,
-			MessageV:   stringPtr(snapshot.Message),
-		})
+		for _, node := range matchedNodes {
+			results[node.ID] = cloneLatencyResolver(&LatencyResolver{
+				NodeID:     node.ID,
+				LatencyMsV: snapshot.LatencyMs,
+				AliveVal:   snapshot.Alive,
+				TestedAtV:  snapshot.CheckedAt,
+				MessageV:   stringPtr(snapshot.Message),
+			})
+		}
 	}
 
-	storeLatencyResults(mapsValues(results))
 	return results, nil
 }
 
@@ -206,7 +207,9 @@ func stringPtr(value string) *string {
 }
 
 func QueryLatencies(ctx context.Context, ids *[]graphql.ID) ([]*LatencyResolver, error) {
-	_ = refreshLatencyCacheIfNeeded(ctx)
+	if err := refreshLatencyCacheIfNeeded(ctx); err != nil {
+		return nil, err
+	}
 
 	nodes, err := latencyProbeNodes(ctx, ids)
 	if err != nil {
@@ -219,7 +222,9 @@ func QueryLatencies(ctx context.Context, ids *[]graphql.ID) ([]*LatencyResolver,
 		return nil, err
 	}
 	for id, resolver := range runtimeResults {
-		merged[id] = resolver
+		if _, ok := merged[id]; !ok {
+			merged[id] = resolver
+		}
 	}
 
 	results := make([]*LatencyResolver, 0, len(nodes))


### PR DESCRIPTION
## Summary

This PR fixes latency result merging in `nodeLatencies`.

Manual probe results should remain authoritative until the cache expires, instead of being overwritten immediately by older runtime latency snapshots.

## What changed

- stop writing runtime snapshot results back into the manual latency cache
- keep cached/manual latency results authoritative when merging with runtime snapshots
- map a runtime latency snapshot to all matching nodes with the same link instead of only one node

## Why

The previous behavior had a few issues:

- manual latency test results could be immediately overwritten by stale runtime snapshot data
- loading runtime snapshot results updated the cache timestamp, which could delay the next intended refresh
- when multiple nodes shared the same link, only one node could receive the merged runtime result

This patch keeps the merge behavior consistent with user expectations:
- manual test first
- runtime snapshot as fallback

## Scope

- backend only
- no schema change
- no API shape change

## Manual verification

- [ ] run manual node latency test and confirm the result remains visible after querying `nodeLatencies`
- [ ] confirm runtime snapshots are still used as fallback when no cached/manual result exists
- [ ] confirm multiple nodes sharing the same link all receive the merged runtime result
